### PR TITLE
LICENSE: add title; use comma after year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2017 Júlio Hoffimann Mendes <juliohm@stanford.edu>
+ISC License
+
+Copyright (c) 2017, Júlio Hoffimann Mendes <juliohm@stanford.edu>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The title is not legally mandated, but it's recommended in the license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).

*This PR is part of a project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*