### PR TITLE
Allow for Haversine distance

### DIFF
--- a/src/LocallyWeightedRegression.jl
+++ b/src/LocallyWeightedRegression.jl
@@ -66,7 +66,12 @@ function solve(problem::EstimationProblem, solver::LocalWeightRegress)
       varσ = Vector{V}(undef, npoints(pdomain))
 
       # fit search tree
-      kdtree = KDTree(X, varparams.distance)
+      M = varparams.distance
+      if M isa NearestNeighbors.MinkowskiMetric
+        tree = KDTree(X, M)
+      else
+        tree = BruteTree(X, M)
+      end
 
       # determine number of nearest neighbors to use
       k = varparams.neighbors == nothing ? ndata : varparams.neighbors
@@ -84,7 +89,7 @@ function solve(problem::EstimationProblem, solver::LocalWeightRegress)
       for location in LinearPath(pdomain)
         coordinates!(x, pdomain, location)
 
-        inds, dists = knn(kdtree, x, k)
+        inds, dists = knn(tree, x, k)
 
         Xₗ = [ones(eltype(X), k) X[:,inds]']
         zₗ = view(z, inds)


### PR DESCRIPTION
This PR is identical to the recent one started in InverseDistanceWeighting.jl. But it does not work on this tiny example:

```julia
using Plots, GeoStats, LocallyWeightedRegression, Distances
x = [50.0, 100.0, 200.0]
y = [-30.0, 30.0, 10.0]
z = [4.0, -1.0, 3.0]
data = OrderedDict(:variable => z)
coord = [(lon,lat) for (lon,lat) in zip(x,y)]
sdata = PointSetData(data, coord)
dims = (180, 89)
start = (1.0, -89.0)
finish = (359.0, 89.0)
sdomain = RegularGrid(start, finish, dims=dims)
problem = EstimationProblem(sdata, sdomain, :variable)
xs = range(start[1], stop=finish[1], length=dims[1])
ys = range(start[2], stop=finish[2], length=dims[2])
NT = (variogram=ExponentialVariogram(), distance=Haversine(1.0),)
solver = LocalWeightRegress(:variable => NT)
solution = GeoStats.solve(problem, solver)
μ, σ = solution[:variable]
plt = contourf(xs, ys, permutedims(μ, (2,1)))
scatter!(plt, sdata)
```

I'm not sure what is wrong but this creates a singular matrix. @juliohm maybe you have another toy example in 2D with another distance that works that I could start with?﻿